### PR TITLE
Add missing dependency

### DIFF
--- a/roles/reviewboard/tasks/main.yml
+++ b/roles/reviewboard/tasks/main.yml
@@ -11,6 +11,7 @@
       - git-core
       - apache2
       - libapache2-mod-wsgi
+      - libjpeg-dev
 
 - name: Install Reviewboard
   easy_install: name={{item}}


### PR DESCRIPTION
Update the dependency list in ansible before ReviewBoard installation. #3 
